### PR TITLE
Fix connection cleanup on send failure

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -40,18 +40,21 @@ export class Globe extends Server {
             position: connection.state!.position,
           } satisfies OutgoingMessage),
         );
+      } catch {
+        this.onCloseOrError(conn);
+      }
 
-        // And let's send the new connection's position to all other connections
-        if (connection.id !== conn.id) {
+      if (connection.id !== conn.id) {
+        try {
           connection.send(
             JSON.stringify({
               type: "add-marker",
               position,
             } satisfies OutgoingMessage),
           );
+        } catch {
+          this.onCloseOrError(connection);
         }
-      } catch {
-        this.onCloseOrError(conn);
       }
     }
   }


### PR DESCRIPTION
## Summary
- ensure failing connections are closed correctly when message send fails

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68523da6c98883228acd1f847e2d1a52