### PR TITLE
Add wind generator concept comparison experience

### DIFF
--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -1,50 +1,347 @@
-/* 
-  We've already included normalize.css. 
-
-  But we'd like a modern looking boilerplate. 
-  Clean type, sans-serif, and a nice color palette. 
-  
-*/
+:root {
+  color-scheme: dark;
+  --background: #070c16;
+  --surface: #101726;
+  --accent: #3aa5f2;
+  --accent-soft: #14334d;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --border: rgba(148, 163, 184, 0.2);
+  --highlight: linear-gradient(135deg, rgba(14, 165, 233, 0.16), rgba(59, 130, 246, 0.16));
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+}
 
 body {
-  font-family: sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  color: #999;
-  background-color: black;
-  text-align: center;
-  padding-top: 40px;
+  margin: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(59, 130, 246, 0.18), transparent),
+    radial-gradient(circle at 80% 0%, rgba(14, 116, 144, 0.15), transparent),
+    var(--background);
+  color: var(--text);
+  line-height: 1.7;
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  font-family: sans-serif;
-  font-weight: 600;
-  line-height: 1.25;
+main.layout {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 64px 24px 96px;
+}
+
+.hero {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-bottom: 40px;
+  text-align: left;
+}
+
+.hero h1 {
+  font-size: clamp(2.4rem, 4vw, 3.2rem);
+  margin: 0;
+  line-height: 1.1;
+}
+
+.hero p {
+  margin: 0;
+  color: var(--muted);
+  max-width: 760px;
+}
+
+.hero .eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.hero-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.hero-nav a {
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  color: var(--text);
+  text-decoration: none;
+  font-size: 0.85rem;
+  background: rgba(15, 23, 42, 0.6);
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.hero-nav a:hover {
+  border-color: rgba(148, 163, 184, 0.5);
+  transform: translateY(-1px);
+}
+
+.callout {
+  padding: 24px;
+  border-radius: 16px;
+  background: var(--highlight);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  box-shadow: 0 18px 60px rgba(15, 118, 222, 0.15);
+  margin-bottom: 48px;
+}
+
+.callout h2 {
   margin-top: 0;
-  margin-bottom: 0.5rem;
+  margin-bottom: 12px;
 }
 
-#app {
-  padding: 1rem;
+.callout p {
+  margin: 0;
+  color: var(--text);
 }
 
-h1 {
-  color: white;
+.methodology {
+  margin-bottom: 48px;
 }
 
-b {
-  color: white;
-  font-weight: bold;
+.method-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
-a {
-  color: #ccc;
-  text-decoration-line: underline;
-  text-underline-offset: 3px;
-  text-decoration-color: #555;
+.method-grid h3 {
+  margin-bottom: 8px;
+}
+
+.design-card {
+  background: rgba(8, 16, 28, 0.65);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: 32px;
+  margin-bottom: 48px;
+  backdrop-filter: blur(18px);
+}
+
+.design-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+
+.llm-badge {
+  align-self: flex-start;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.2);
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+}
+
+.tagline {
+  color: rgba(226, 232, 240, 0.78);
+  font-size: 1rem;
+}
+
+.design-body {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+  gap: 28px;
+  align-items: start;
+}
+
+.design-summary p {
+  margin-top: 0;
+}
+
+.design-summary ul,
+.method-grid ul,
+.next-steps ul {
+  margin: 0;
+  padding-left: 20px;
+  color: var(--muted);
+}
+
+.assumption-list {
+  margin-top: 16px;
+  font-size: 0.95rem;
+}
+
+.design-visual {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: center;
+}
+
+.diagram {
+  width: min(100%, 280px);
+  height: auto;
+  background: rgba(15, 23, 42, 0.9);
+  border-radius: 20px;
+  padding: 12px;
+  border: 1px solid rgba(59, 130, 246, 0.25);
+}
+
+.highlight {
+  text-align: center;
+  border-radius: 16px;
+  padding: 16px;
+  background: rgba(59, 130, 246, 0.1);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  width: 100%;
+}
+
+.highlight-label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.highlight-value {
+  font-size: 1.9rem;
+  margin: 8px 0 4px;
+}
+
+.highlight-sub {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.78);
+}
+
+.design-footer h3 {
+  margin-bottom: 12px;
+}
+
+.innovation-list {
+  margin: 0 0 20px;
+  padding-left: 20px;
+  color: var(--muted);
+}
+
+.detail-table,
+.comparison-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.detail-table thead th,
+.comparison-table thead th {
+  text-align: left;
+  padding-bottom: 10px;
+  color: rgba(148, 163, 184, 0.9);
+  border-bottom: 1px solid var(--border);
+}
+
+.detail-table tbody td,
+.comparison-table tbody td {
+  padding: 10px 6px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.comparison-table tbody tr:hover {
+  background: rgba(59, 130, 246, 0.06);
+}
+
+.llm-inline {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.best-cell {
+  font-weight: 600;
+  color: #38bdf8;
+}
+
+.insight-list {
+  margin: 16px 0;
+  display: grid;
+  gap: 12px;
+}
+
+.insight-item {
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(9, 14, 26, 0.55);
+}
+
+.insight-item dt {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.insight-item dd {
+  margin: 0;
+  color: var(--muted);
+}
+
+.productivity,
+.comparison,
+.methodology,
+.next-steps {
+  margin-bottom: 48px;
+}
+
+.productivity p,
+.comparison p {
+  color: var(--muted);
+}
+
+.formula {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 2px 6px;
+  border-radius: 6px;
+  background: rgba(59, 130, 246, 0.14);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  font-family: "JetBrains Mono", "Menlo", monospace;
+  font-size: 0.9rem;
+  color: #7dd3fc;
+}
+
+.calculation-steps {
+  margin: 20px 0;
+  padding-left: 20px;
+  color: var(--muted);
+}
+
+.calculation-steps li {
+  margin-bottom: 8px;
+}
+
+.next-steps ul li {
+  margin-bottom: 8px;
+}
+
+.footer {
+  border-top: 1px solid var(--border);
+  padding-top: 24px;
+  color: rgba(148, 163, 184, 0.7);
+  text-align: center;
+}
+
+@media (max-width: 900px) {
+  .design-body {
+    grid-template-columns: 1fr;
+  }
+
+  .hero {
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 640px) {
+  main.layout {
+    padding: 48px 18px 72px;
+  }
+
+  .design-card {
+    padding: 24px;
+  }
+
+  .hero-nav {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }


### PR DESCRIPTION
## Summary
- replace the previous globe demo with a narrative comparing three LLM-generated high-output wind generator concepts
- add inline SVG diagrams, KM/h productivity calculations, and comparison tables for each concept
- refresh the client styling to support the new editorial layout and highlight key callouts

## Testing
- npm run check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68d6bebfb398832292bef72a7fac006d)