### PR TITLE
Add action approval workflow, logging, and dashboard UI

### DIFF
--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -6,7 +6,12 @@ import createGlobe from "cobe";
 import usePartySocket from "partysocket/react";
 
 // The type of messages we'll be receiving from the server
-import type { OutgoingMessage } from "../shared";
+import type {
+  ActionLogEntry,
+  ActionRequest,
+  IncomingMessage,
+  OutgoingMessage,
+} from "../shared";
 import type { LegacyRef } from "react";
 
 function App() {
@@ -14,6 +19,10 @@ function App() {
   const canvasRef = useRef<HTMLCanvasElement>();
   // The number of markers we're currently displaying
   const [counter, setCounter] = useState(0);
+  const [pendingActions, setPendingActions] = useState<ActionRequest[]>([]);
+  const [actionLog, setActionLog] = useState<ActionLogEntry[]>([]);
+  const [deletePath, setDeletePath] = useState("/tmp/example.txt");
+  const [packageName, setPackageName] = useState("lodash");
   // A map of marker IDs to their positions
   // Note that we use a ref because the globe's `onRender` callback
   // is called on every animation frame, and we don't want to re-render
@@ -32,7 +41,9 @@ function App() {
     room: "default",
     party: "globe",
     onMessage(evt) {
-      const message = JSON.parse(evt.data as string) as OutgoingMessage;
+      const message = JSON.parse(evt.data as string) as
+        | OutgoingMessage
+        | IncomingMessage;
       if (message.type === "add-marker") {
         // Add the marker to our map
         positions.current.set(message.position.id, {
@@ -41,14 +52,58 @@ function App() {
         });
         // Update the counter
         setCounter((c) => c + 1);
-      } else {
+      } else if (message.type === "remove-marker") {
         // Remove the marker from our map
         positions.current.delete(message.id);
         // Update the counter
         setCounter((c) => c - 1);
+      } else if (message.type === "action:state") {
+        setPendingActions(message.pending);
+        setActionLog(message.log);
+      } else if (message.type === "action:request") {
+        setPendingActions((current) => {
+          if (current.some((action) => action.id === message.action.id)) {
+            return current;
+          }
+          return [message.action, ...current];
+        });
       }
     },
   });
+
+  const submitDeleteAction = () => {
+    socket.send(
+      JSON.stringify({
+        type: "action:submit",
+        action: {
+          kind: "delete-file",
+          payload: { path: deletePath },
+        },
+      } satisfies IncomingMessage),
+    );
+  };
+
+  const submitInstallAction = () => {
+    socket.send(
+      JSON.stringify({
+        type: "action:submit",
+        action: {
+          kind: "install-package",
+          payload: { packageName },
+        },
+      } satisfies IncomingMessage),
+    );
+  };
+
+  const decideAction = (id: string, decision: "approved" | "rejected") => {
+    socket.send(
+      JSON.stringify({
+        type: "action:decision",
+        id,
+        decision,
+      } satisfies IncomingMessage),
+    );
+  };
 
   useEffect(() => {
     // The angle of rotation of the globe
@@ -111,6 +166,120 @@ function App() {
         <a href="https://www.npmjs.com/package/phenomenon">Phenomenon</a> and{" "}
         <a href="https://npmjs.com/package/partyserver/">🎈 PartyServer</a>
       </p>
+
+      <section className="dashboard">
+        <h2>Action approvals</h2>
+        <p className="dashboard__subtitle">
+          Sensitive actions emit an approval request before they execute.
+        </p>
+
+        <div className="dashboard__panels">
+          <div className="dashboard__panel">
+            <h3>Request an action</h3>
+            <div className="dashboard__form">
+              <label className="dashboard__field">
+                Delete file path
+                <input
+                  value={deletePath}
+                  onChange={(event) => setDeletePath(event.target.value)}
+                />
+                <button type="button" onClick={submitDeleteAction}>
+                  Request delete
+                </button>
+              </label>
+              <label className="dashboard__field">
+                Install package
+                <input
+                  value={packageName}
+                  onChange={(event) => setPackageName(event.target.value)}
+                />
+                <button type="button" onClick={submitInstallAction}>
+                  Request install
+                </button>
+              </label>
+            </div>
+          </div>
+
+          <div className="dashboard__panel">
+            <h3>Pending approvals</h3>
+            {pendingActions.length === 0 ? (
+              <p className="dashboard__empty">No pending approvals.</p>
+            ) : (
+              <ul className="dashboard__list">
+                {pendingActions.map((action) => (
+                  <li key={action.id} className="dashboard__item">
+                    <div>
+                      <strong>{action.kind}</strong>
+                      <span className="dashboard__meta">
+                        Requested by {action.requestedBy}
+                      </span>
+                      {"path" in action.payload ? (
+                        <span className="dashboard__detail">
+                          Path: {action.payload.path}
+                        </span>
+                      ) : (
+                        <span className="dashboard__detail">
+                          Package: {action.payload.packageName}
+                        </span>
+                      )}
+                    </div>
+                    <div className="dashboard__actions">
+                      <button
+                        type="button"
+                        onClick={() => decideAction(action.id, "approved")}
+                      >
+                        Approve
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => decideAction(action.id, "rejected")}
+                      >
+                        Reject
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+
+        <div className="dashboard__panel">
+          <h3>Decision log</h3>
+          {actionLog.length === 0 ? (
+            <p className="dashboard__empty">No actions have been reviewed.</p>
+          ) : (
+            <ul className="dashboard__list">
+              {actionLog.map((entry) => (
+                <li key={entry.id} className="dashboard__item">
+                  <div>
+                    <strong>
+                      {entry.kind} ({entry.status})
+                    </strong>
+                    <span className="dashboard__meta">
+                      Reviewed by {entry.decidedBy}
+                    </span>
+                    {"path" in entry.payload ? (
+                      <span className="dashboard__detail">
+                        Path: {entry.payload.path}
+                      </span>
+                    ) : (
+                      <span className="dashboard__detail">
+                        Package: {entry.payload.packageName}
+                      </span>
+                    )}
+                    {entry.result ? (
+                      <span className="dashboard__detail">
+                        Result: {entry.result}
+                      </span>
+                    ) : null}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -48,3 +48,99 @@ a {
   text-underline-offset: 3px;
   text-decoration-color: #555;
 }
+
+.dashboard {
+  margin: 2.5rem auto 0;
+  max-width: 900px;
+  text-align: left;
+  color: #d6d6d6;
+}
+
+.dashboard__subtitle {
+  margin-bottom: 1.5rem;
+  color: #9b9b9b;
+}
+
+.dashboard__panels {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.dashboard__panel {
+  border: 1px solid #2c2c2c;
+  border-radius: 12px;
+  padding: 1.25rem;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.dashboard__form {
+  display: grid;
+  gap: 1rem;
+}
+
+.dashboard__field {
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.dashboard__field input {
+  background: #111;
+  color: #f2f2f2;
+  border: 1px solid #333;
+  border-radius: 8px;
+  padding: 0.5rem 0.75rem;
+}
+
+.dashboard__field button,
+.dashboard__actions button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  background: #2e70ff;
+  color: white;
+  cursor: pointer;
+  font-weight: 600;
+  margin-top: 0.25rem;
+}
+
+.dashboard__actions button:last-child {
+  background: #444;
+}
+
+.dashboard__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.dashboard__item {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  border: 1px solid #222;
+  border-radius: 10px;
+  padding: 0.75rem;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.dashboard__meta,
+.dashboard__detail {
+  display: block;
+  font-size: 0.8rem;
+  color: #a2a2a2;
+}
+
+.dashboard__actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.dashboard__empty {
+  color: #7a7a7a;
+  font-size: 0.9rem;
+}

--- a/src/server/commands.ts
+++ b/src/server/commands.ts
@@ -1,0 +1,89 @@
+import type {
+  ActionKind,
+  ActionLogEntry,
+  ActionPayloadByKind,
+  ActionRequest,
+} from "../shared";
+
+type ActionExecutionResult = {
+  ok: boolean;
+  message: string;
+};
+
+type ActionDecision = {
+  status: "approved" | "rejected";
+  decidedBy: string;
+  decidedAt: string;
+};
+
+export type ActionState = {
+  pending: ActionRequest[];
+  log: ActionLogEntry[];
+};
+
+export function createActionRequest<K extends ActionKind>(
+  kind: K,
+  payload: ActionPayloadByKind[K],
+  requestedBy: string,
+): ActionRequest {
+  return {
+    id: crypto.randomUUID(),
+    kind,
+    payload,
+    requestedAt: new Date().toISOString(),
+    requestedBy,
+  };
+}
+
+export async function executeAction(
+  kind: ActionKind,
+  payload: ActionPayloadByKind[ActionKind],
+): Promise<ActionExecutionResult> {
+  switch (kind) {
+    case "delete-file":
+      return simulateDeleteFile(payload);
+    case "install-package":
+      return simulateInstallPackage(payload);
+    default: {
+      const unreachable: never = kind;
+      return {
+        ok: false,
+        message: `Unknown action ${unreachable}`,
+      };
+    }
+  }
+}
+
+export function createActionLogEntry(
+  action: ActionRequest,
+  decision: ActionDecision,
+  result?: ActionExecutionResult,
+): ActionLogEntry {
+  return {
+    id: action.id,
+    kind: action.kind,
+    payload: action.payload,
+    requestedAt: action.requestedAt,
+    requestedBy: action.requestedBy,
+    decidedAt: decision.decidedAt,
+    decidedBy: decision.decidedBy,
+    status: decision.status,
+    result: result?.message,
+  };
+}
+
+function simulateDeleteFile(payload: ActionPayloadByKind["delete-file"]) {
+  return Promise.resolve<ActionExecutionResult>({
+    ok: true,
+    message: `Simulated deletion of ${payload.path}.`,
+  });
+}
+
+function simulateInstallPackage(
+  payload: ActionPayloadByKind["install-package"],
+) {
+  return Promise.resolve<ActionExecutionResult>({
+    ok: true,
+    message: `Simulated installation of ${payload.packageName}.`,
+  });
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,7 +1,19 @@
 import { routePartykitRequest, Server } from "partyserver";
 
-import type { OutgoingMessage, Position } from "../shared";
+import type {
+  ActionLogEntry,
+  ActionRequest,
+  IncomingMessage,
+  OutgoingMessage,
+  Position,
+} from "../shared";
 import type { Connection, ConnectionContext } from "partyserver";
+import {
+  createActionLogEntry,
+  createActionRequest,
+  executeAction,
+  type ActionState,
+} from "./commands";
 
 // This is the state that we'll store on each connection
 type ConnectionState = {
@@ -9,6 +21,15 @@ type ConnectionState = {
 };
 
 export class Globe extends Server {
+  private actionLog: ActionLogEntry[] = [];
+  private pendingActions: ActionRequest[] = [];
+
+  async onStart() {
+    const stored = await this.ctx.storage.get<ActionState>("actionState");
+    this.actionLog = stored?.log ?? [];
+    this.pendingActions = stored?.pending ?? [];
+  }
+
   onConnect(conn: Connection<ConnectionState>, ctx: ConnectionContext) {
     // Whenever a fresh connection is made, we'll
     // send the entire state to the new connection
@@ -57,6 +78,8 @@ export class Globe extends Server {
         }
       }
     }
+
+    this.sendActionState(conn);
   }
 
   // Whenever a connection closes (or errors), we'll broadcast a message to all
@@ -77,6 +100,93 @@ export class Globe extends Server {
 
   onError(connection: Connection): void | Promise<void> {
     this.onCloseOrError(connection);
+  }
+
+  async onMessage(connection: Connection, message: string | ArrayBuffer) {
+    if (typeof message !== "string") {
+      return;
+    }
+    let parsed: IncomingMessage;
+    try {
+      parsed = JSON.parse(message) as IncomingMessage;
+    } catch {
+      return;
+    }
+
+    if (parsed.type === "action:submit") {
+      const request = createActionRequest(
+        parsed.action.kind,
+        parsed.action.payload,
+        connection.id,
+      );
+      this.pendingActions = [...this.pendingActions, request];
+      await this.persistActionState();
+      this.broadcast(
+        JSON.stringify({
+          type: "action:request",
+          action: request,
+        } satisfies OutgoingMessage),
+      );
+      this.broadcastActionState();
+      return;
+    }
+
+    if (parsed.type === "action:decision") {
+      const targetIndex = this.pendingActions.findIndex(
+        (action) => action.id === parsed.id,
+      );
+      if (targetIndex === -1) {
+        return;
+      }
+
+      const [action] = this.pendingActions.splice(targetIndex, 1);
+      const decision = {
+        status: parsed.decision,
+        decidedBy: connection.id,
+        decidedAt: new Date().toISOString(),
+      } as const;
+
+      const result =
+        parsed.decision === "approved"
+          ? await executeAction(action.kind, action.payload)
+          : undefined;
+
+      const logEntry = createActionLogEntry(action, decision, result);
+      this.actionLog = [logEntry, ...this.actionLog].slice(0, 100);
+      await this.persistActionState();
+      this.broadcastActionState();
+    }
+  }
+
+  private async persistActionState() {
+    await this.ctx.storage.put<ActionState>("actionState", {
+      pending: this.pendingActions,
+      log: this.actionLog,
+    });
+  }
+
+  private sendActionState(connection: Connection) {
+    try {
+      connection.send(
+        JSON.stringify({
+          type: "action:state",
+          pending: this.pendingActions,
+          log: this.actionLog,
+        } satisfies OutgoingMessage),
+      );
+    } catch {
+      this.onCloseOrError(connection);
+    }
+  }
+
+  private broadcastActionState() {
+    this.broadcast(
+      JSON.stringify({
+        type: "action:state",
+        pending: this.pendingActions,
+        log: this.actionLog,
+      } satisfies OutgoingMessage),
+    );
   }
 }
 

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -15,4 +15,62 @@ export type OutgoingMessage =
   | {
       type: "remove-marker";
       id: string;
+    }
+  | {
+      type: "action:request";
+      action: ActionRequest;
+    }
+  | {
+      type: "action:state";
+      pending: ActionRequest[];
+      log: ActionLogEntry[];
+    };
+
+export type ActionKind = "delete-file" | "install-package";
+
+export type DeleteFilePayload = {
+  path: string;
+};
+
+export type InstallPackagePayload = {
+  packageName: string;
+};
+
+export type ActionPayloadByKind = {
+  "delete-file": DeleteFilePayload;
+  "install-package": InstallPackagePayload;
+};
+
+export type ActionRequest = {
+  id: string;
+  kind: ActionKind;
+  payload: ActionPayloadByKind[ActionKind];
+  requestedAt: string;
+  requestedBy: string;
+};
+
+export type ActionLogEntry = {
+  id: string;
+  kind: ActionKind;
+  payload: ActionPayloadByKind[ActionKind];
+  requestedAt: string;
+  requestedBy: string;
+  decidedAt: string;
+  decidedBy: string;
+  status: "approved" | "rejected";
+  result?: string;
+};
+
+export type IncomingMessage =
+  | {
+      type: "action:submit";
+      action: {
+        kind: ActionKind;
+        payload: ActionPayloadByKind[ActionKind];
+      };
+    }
+  | {
+      type: "action:decision";
+      id: string;
+      decision: "approved" | "rejected";
     };


### PR DESCRIPTION
### Motivation
- Introduce a safe command handling layer for sensitive operations (file deletion, package installs) that requires explicit approval before execution.
- Emit events and surface pending approvals so operators can review and approve/reject actions via the dashboard UI.
- Persist approved/rejected actions to Durable Object storage so the audit log and pending state survive restarts.
- Provide a simple simulated executor so the approval flow can be tested without executing destructive operations.

### Description
- Added shared action types and message shapes in `src/shared.ts` (`ActionRequest`, `ActionLogEntry`, `IncomingMessage`, `OutgoingMessage` variants).
- Implemented a command handler module `src/server/commands.ts` with `createActionRequest`, `executeAction` (simulated), and `createActionLogEntry` helpers and an `ActionState` shape.
- Extended the Durable Object `Globe` server (`src/server/index.ts`) to persist pending/log state via `this.ctx.storage`, emit `action:request` and `action:state` events, handle `action:submit` / `action:decision` messages, and execute actions only after approval.
- Updated the frontend (`src/client/index.tsx`, `src/client/styles.css`) to let clients submit action requests, view pending approvals, approve/reject items, and view the decision log.

### Testing
- Started the development server with `npm run dev` (which runs `wrangler dev`) and the custom esbuild build; the build and local worker started successfully.
- Verified asset build output from esbuild (generated `public/dist/index.js` and maps) during `npm run dev` which completed successfully.
- Queried the local server with `curl -I http://127.0.0.1:8787` and received `HTTP/1.1 200 OK`, confirming the worker responded.
- Attempted automated UI capture via Playwright to screenshot the dashboard but the Playwright navigation failed with `net::ERR_EMPTY_RESPONSE`, so the browser-run verification did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964c934d7f48322bdc24eaa85d6284a)